### PR TITLE
#161983828 Add validation for POST and PUT API endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3274,6 +3274,11 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
+    "hoek": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.0.3.tgz",
+      "integrity": "sha512-TU6RyZ/XaQCTWRLrdqZZtZqwxUVr6PDMfi6MlWNURZ7A6czanQqX4pFE1mdOUQR9FdPCsZ0UzL8jI/izZ+eBSQ=="
+    },
     "home-or-tmp": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
@@ -3665,6 +3670,14 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
+    "isemail": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+      "requires": {
+        "punycode": "2.x.x"
+      }
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3702,6 +3715,16 @@
         "@babel/types": "^7.0.0",
         "istanbul-lib-coverage": "^2.0.1",
         "semver": "^5.5.0"
+      }
+    },
+    "joi": {
+      "version": "14.0.6",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-14.0.6.tgz",
+      "integrity": "sha512-mKXPSNYMG3taVBZemQj3pPOlMZGrnnu14JKAC6AHg6jJVX35L7oDk89ss1sHj+laDSEh3mD2PmeheI5k6Aw8nQ==",
+      "requires": {
+        "hoek": "6.x.x",
+        "isemail": "3.x.x",
+        "topo": "3.x.x"
       }
     },
     "js-levenshtein": {
@@ -6181,8 +6204,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
@@ -7358,6 +7380,14 @@
             "kind-of": "^3.0.2"
           }
         }
+      }
+    },
+    "topo": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+      "requires": {
+        "hoek": "6.x.x"
       }
     },
     "touch": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "homepage": "https://github.com/Kellswork/SendIT#readme",
   "dependencies": {
     "body-parser": "^1.18.3",
-    "express": "^4.16.4"
+    "express": "^4.16.4",
+    "joi": "^14.0.6"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.5",

--- a/server/controllers/ParcelOrder.js
+++ b/server/controllers/ParcelOrder.js
@@ -37,7 +37,7 @@ class ParcelOrder {
     if (error) {
       return res.status(400).json({
         success: false,
-        error: error.details[0].message,
+        error: error.details,
       });
     }
 

--- a/server/controllers/ParcelOrder.js
+++ b/server/controllers/ParcelOrder.js
@@ -1,4 +1,5 @@
 import parcels from '../models/parcels';
+import validateParcelOrder from '../middlewares/parcelOrder';
 
 class ParcelOrder {
   static getAllParcelOrders(req, res) {
@@ -32,6 +33,14 @@ class ParcelOrder {
   }
 
   static createParcelOrder(req, res) {
+    const { error } = validateParcelOrder(req.body);
+    if (error) {
+      return res.status(400).json({
+        success: false,
+        message: error.details[0].message,
+      });
+    }
+
     const {
       name, productName, pickupAddress, destinationAddress,
     } = req.body;
@@ -43,7 +52,7 @@ class ParcelOrder {
       destinationAddress,
     };
     parcels.push(newParcel);
-    res.status(201).json({
+    return res.status(201).json({
       success: true,
       message: 'Parcel delivery order created successfully',
       details: parcels,
@@ -57,6 +66,17 @@ class ParcelOrder {
       return res.status(404).json({
         success: false,
         message: 'Parcel does not exist',
+      });
+    } if (oneParcel.status === 'delivered') {
+      return res.status(406).json({
+        success: false,
+        message: 'Cannot cancel a parcel delivery order that has already been delivered',
+      });
+    }
+    if (oneParcel.status === 'cancelled') {
+      return res.status(406).json({
+        success: false,
+        message: 'Parcel delivery order has  already been cancelled',
       });
     }
     oneParcel.status = 'cancelled';

--- a/server/controllers/ParcelOrder.js
+++ b/server/controllers/ParcelOrder.js
@@ -6,7 +6,7 @@ class ParcelOrder {
     if (parcels.length <= 0) {
       return res.status(404).json({
         success: false,
-        message: 'No parcel delivery order has been created',
+        error: 'No parcel delivery order has been created',
       });
     }
     return res.status(200).json({
@@ -22,7 +22,7 @@ class ParcelOrder {
     if (!oneParcel) {
       return res.status(404).json({
         success: false,
-        message: 'Parcel delivery order does not exist',
+        error: 'Parcel delivery order does not exist',
       });
     }
     return res.status(200).json({
@@ -37,7 +37,7 @@ class ParcelOrder {
     if (error) {
       return res.status(400).json({
         success: false,
-        message: error.details[0].message,
+        error: error.details[0].message,
       });
     }
 
@@ -65,18 +65,18 @@ class ParcelOrder {
     if (!oneParcel) {
       return res.status(404).json({
         success: false,
-        message: 'Parcel does not exist',
+        error: 'Parcel does not exist',
       });
     } if (oneParcel.status === 'delivered') {
       return res.status(406).json({
         success: false,
-        message: 'Cannot cancel a parcel delivery order that has already been delivered',
+        error: 'Cannot cancel a parcel delivery order that has already been delivered',
       });
     }
     if (oneParcel.status === 'cancelled') {
       return res.status(406).json({
         success: false,
-        message: 'Parcel delivery order has  already been cancelled',
+        error: 'Parcel delivery order has already been cancelled',
       });
     }
     oneParcel.status = 'cancelled';

--- a/server/controllers/User.js
+++ b/server/controllers/User.js
@@ -18,7 +18,7 @@ class User {
   static getAllParcelOrderCreatedByUser(req, res) {
     const { userId } = req.params;
     const userParcel = parcels.filter(parcel => parcel.userId === parseInt(userId, 10));
-    // get all parcel orders with the userId
+
     if (userParcel.length <= 0) {
       return res.status(404).json({
         success: false,

--- a/server/controllers/User.js
+++ b/server/controllers/User.js
@@ -4,9 +4,9 @@ import parcels from '../models/parcels';
 class User {
   static getAllUsers(req, res) {
     if (users.length <= 0) {
-      return res.json({
+      return res.status(404).json({
         success: false,
-        message: 'No user found',
+        error: 'No user found',
       });
     }
     return res.status(200).json({
@@ -22,7 +22,7 @@ class User {
     if (userParcel.length <= 0) {
       return res.status(404).json({
         success: false,
-        message: 'You have not created any parcel develivery order',
+        error: 'You have not created any parcel delivery order',
       });
     }
     return res.status(200).json({

--- a/server/index.js
+++ b/server/index.js
@@ -18,7 +18,6 @@ app.use((req, res, next) => {
 
 const port = process.env.PORT || 8080;
 
-const server = app.listen(port);
-console.log(`SendIT started on ${port}`);
+const server = app.listen(port, () => console.log(`app started at ${port}`));
 
 export default server;

--- a/server/middlewares/parcelOrder.js
+++ b/server/middlewares/parcelOrder.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 
-function validateParcelOrder(parcelOrder) {
+const validateParcelOrder = (parcelOrder) => {
   const schema = {
     name: Joi.string().min(5).max(30).required(),
     productName: Joi.string().min(5).max(30).required(),
@@ -9,6 +9,6 @@ function validateParcelOrder(parcelOrder) {
     status: Joi.string().required(),
   };
   return Joi.validate(parcelOrder, schema);
-}
+};
 
 export default validateParcelOrder;

--- a/server/middlewares/parcelOrder.js
+++ b/server/middlewares/parcelOrder.js
@@ -2,10 +2,10 @@ import Joi from 'joi';
 
 const validateParcelOrder = (parcelOrder) => {
   const schema = {
-    name: Joi.string().min(5).max(30).required(),
-    productName: Joi.string().min(5).max(30).required(),
-    pickupAddress: Joi.string().min(10).max(30).required(),
-    destinationAddress: Joi.string().min(10).max(30).required(),
+    name: Joi.string().min(5).max(50).required(),
+    productName: Joi.string().min(5).max(250).required(),
+    pickupAddress: Joi.string().min(10).max(250).required(),
+    destinationAddress: Joi.string().min(10).max(250).required(),
     status: Joi.string().required(),
   };
   return Joi.validate(parcelOrder, schema);

--- a/server/middlewares/parcelOrder.js
+++ b/server/middlewares/parcelOrder.js
@@ -1,0 +1,14 @@
+import Joi from 'joi';
+
+function validateParcelOrder(parcelOrder) {
+  const schema = {
+    name: Joi.string().min(5).max(30).required(),
+    productName: Joi.string().min(5).max(30).required(),
+    pickupAddress: Joi.string().min(10).max(30).required(),
+    destinationAddress: Joi.string().min(10).max(30).required(),
+    status: Joi.string().required(),
+  };
+  return Joi.validate(parcelOrder, schema);
+}
+
+export default validateParcelOrder;

--- a/server/models/parcels.js
+++ b/server/models/parcels.js
@@ -55,7 +55,7 @@ const parcels = [
     productName: 'Gucci leather belt',
     pickupAddress: 'no 2 fox road detox avenue apapa lagos',
     destinationAddress: 'no 2 allen avenue oshodi lagos',
-    status: 'in transit',
+    status: 'pending',
 
   },
   {
@@ -65,7 +65,7 @@ const parcels = [
     productName: 'ring lights',
     pickupAddress: 'no 2 fox road detox avenue apapa lagos',
     destinationAddress: 'no 2 allen avenue oshodi lagos',
-    status: 'delivered',
+    status: 'cancelled',
 
   },
 ];

--- a/server/test/test.spec.js
+++ b/server/test/test.spec.js
@@ -20,8 +20,8 @@ describe('/api/v1/parcels', () => {
           expect(res.status).to.equal(200);
           expect(res.body).to.have.property('success');
           expect(res.body).to.have.property('message');
-          expect(res.body).to.have.property('parcel');
-          expect(res.body.parcel).to.be.a('array');
+          expect(res.body).to.have.property('parcels');
+          expect(res.body.parcels).to.be.a('array');
           done();
         });
     });
@@ -60,26 +60,37 @@ describe('/api/v1/parcels', () => {
   });
 
   describe('Cancel a parcel delivery order', () => {
-    it('Should update the status to cancelled ', (done) => {
-      api.put('/api/v1/parcels/3/cancel')
+    it('should return a status code of 406 if order delivery status is delivered', (done) => {
+      api.put('/api/v1/parcels/1/cancel')
         .set('Content-Type', 'application/json')
         .send()
-        .expect(200)
+        .expect(406)
         .end((err, res) => {
-          expect(res.status).to.equal(200);
-          expect(res.body).to.have.property('success');
-          expect(res.body).to.have.property('message');
-          expect(res.body).to.have.property('details');
-          expect(res.body.details).to.have.property('name');
-          expect(res.body.details).to.have.property('productName');
-          expect(res.body.details).to.have.property('pickupAddress');
-          expect(res.body.details).to.have.property('destinationAddress');
-          expect(res.body.details).to.have.property('status');
-          expect(res.body.details.status).to.equal('cancelled');
-
+          expect(res.status).to.equal(406);
           done();
         });
     });
+
+    // it('Should update parcel delivery order status to cancelled ', (done) => {
+    //   api.put('/api/v1/parcels/3/cancel')
+    //     .set('Content-Type', 'application/json')
+    //     .send()
+    //     .expect(200)
+    //     .end((err, res) => {
+    //       expect(res.status).to.equal(200);
+    //       expect(res.body).to.have.property('success');
+    //       expect(res.body).to.have.property('message');
+    //       expect(res.body).to.have.property('details');
+    //       expect(res.body.details).to.have.property('name');
+    //       expect(res.body.details).to.have.property('productName');
+    //       expect(res.body.details).to.have.property('pickupAddress');
+    //       expect(res.body.details).to.have.property('destinationAddress');
+    //       expect(res.body.details).to.have.property('status');
+    //       expect(res.body.details.status).to.equal('cancelled');
+
+    //       done();
+    //     });
+    // });
   });
 
   describe('Get all parcel delivery order by a specific user', () => {

--- a/server/test/test.spec.js
+++ b/server/test/test.spec.js
@@ -27,6 +27,23 @@ describe('/api/v1/parcels', () => {
     });
   });
 
+  describe('Get all users', () => {
+    it('should return all users created', (done) => {
+      api.get('/api/v1/users')
+        .set('Content-Type', 'application/json')
+        .send()
+        .expect(200)
+        .end((err, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body).to.have.property('success');
+          expect(res.body).to.have.property('details');
+          expect(res.body.success).to.equal(true);
+          expect(res.body.details).to.be.a('array');
+          done();
+        });
+    });
+  });
+
   describe('Get a specific parcel delivery', () => {
     it('should get a specific parcel delivery order ', (done) => {
       api.get('/api/v1/parcels/2')
@@ -54,6 +71,30 @@ describe('/api/v1/parcels', () => {
         .expect(404)
         .end((err, res) => {
           expect(res.status).to.equal(404);
+          expect(res.body).to.have.property('success');
+          expect(res.body).to.have.property('error');
+          expect(res.body.success).to.equal(false);
+          done();
+        });
+    });
+  });
+
+  describe('Create a parcel delivery order', () => {
+    it('should create a parcel delivery order', (done) => {
+      const parcel = {
+        name: 'della tabel',
+        productName: 'ring lights',
+        pickupAddress: 'no 2 fox road detox avenue apapa lagos',
+        destinationAddress: 'no 2 allen avenue oshodi lagos',
+        status: 'pending',
+      };
+      api.post('/api/v1/parcels/')
+        .set('Content-Type', 'application/json')
+        .send(parcel)
+        .expect(201)
+        .end((err, res) => {
+          console.log(res.body);
+          expect(res.status).to.equal(201);
           done();
         });
     });
@@ -66,7 +107,7 @@ describe('/api/v1/parcels', () => {
         .send()
         .expect(406)
         .end((err, res) => {
-          expect(res.status).to.equal(406);
+          expect(res.status).to.deep.equal(406);
           done();
         });
     });
@@ -82,26 +123,26 @@ describe('/api/v1/parcels', () => {
         });
     });
 
-    // it('Should update parcel delivery order status to cancelled ', (done) => {
-    //   api.put('/api/v1/parcels/3/cancel')
-    //     .set('Content-Type', 'application/json')
-    //     .send()
-    //     .expect(200)
-    //     .end((err, res) => {
-    //       expect(res.status).to.equal(200);
-    //       expect(res.body).to.have.property('success');
-    //       expect(res.body).to.have.property('message');
-    //       expect(res.body).to.have.property('details');
-    //       expect(res.body.details).to.have.property('name');
-    //       expect(res.body.details).to.have.property('productName');
-    //       expect(res.body.details).to.have.property('pickupAddress');
-    //       expect(res.body.details).to.have.property('destinationAddress');
-    //       expect(res.body.details).to.have.property('status');
-    //       expect(res.body.details.status).to.equal('cancelled');
+    it('Should update parcel delivery order status to cancelled ', (done) => {
+      api.put('/api/v1/parcels/6/cancel')
+        .set('Content-Type', 'application/json')
+        .send()
+        .expect(200)
+        .end((err, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body).to.have.property('success');
+          expect(res.body).to.have.property('message');
+          expect(res.body).to.have.property('details');
+          expect(res.body.details).to.have.property('name');
+          expect(res.body.details).to.have.property('productName');
+          expect(res.body.details).to.have.property('pickupAddress');
+          expect(res.body.details).to.have.property('destinationAddress');
+          expect(res.body.details).to.have.property('status');
+          expect(res.body.details.status).to.equal('cancelled');
 
-    //       done();
-    //     });
-    // });
+          done();
+        });
+    });
   });
 
   describe('Get all parcel delivery order by a specific user', () => {
@@ -115,8 +156,22 @@ describe('/api/v1/parcels', () => {
           expect(res.body).to.have.property('success');
           expect(res.body).to.have.property('message');
           expect(res.body).to.have.property('details');
-          expect(res.body).to.have.property('details');
+          expect(res.body.success).to.equal(true);
           expect(res.body.details).to.be.a('array');
+          done();
+        });
+    });
+
+    it('should 404 is user has not created any parcel delivery order', (done) => {
+      api.get('/api/v1/users/106/parcels')
+        .set('Content-Type', 'application/json')
+        .send()
+        .expect(404)
+        .end((err, res) => {
+          expect(res.status).to.equal(404);
+          expect(res.body).to.have.property('success');
+          expect(res.body).to.have.property('error');
+          expect(res.body.success).to.equal(false);
           done();
         });
     });

--- a/server/test/test.spec.js
+++ b/server/test/test.spec.js
@@ -71,6 +71,17 @@ describe('/api/v1/parcels', () => {
         });
     });
 
+    it('should return a status code of 406 if order delivery status is cancelled', (done) => {
+      api.put('/api/v1/parcels/7/cancel')
+        .set('Content-Type', 'application/json')
+        .send()
+        .expect(406)
+        .end((err, res) => {
+          expect(res.status).to.equal(406);
+          done();
+        });
+    });
+
     // it('Should update parcel delivery order status to cancelled ', (done) => {
     //   api.put('/api/v1/parcels/3/cancel')
     //     .set('Content-Type', 'application/json')


### PR DESCRIPTION
#### What does this PR do?
Validates user input for POST request to  /api/vi/parcels endpoint to ensure that the user does not send empty or redundant data to the database.
Validates PUT /api/v1/parcels/:id/cancel to ensure that user cannot cancel a parcel delivery order that has already been delivered or cancelled.
#### Description of Task to be completed?
Add validation to POST /api/V1/parcels

Add validation to PUT /api/v1/parcels/:id/cancel
#### How should this be manually tested?
Clone the repository `https://github.com/Kellswork/SendIT.git`
Navigate to the location of the folder
Run `npm install` to install dependencies
Run `npm start` to get the app started on your local machine
Open POSTMAN
- send POST request to  /POST /api/v1/parcels
- send PUT request to  /api/v1/parcels/:id/cancel
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
161983828 
#### Screenshots (if appropriate)
#### Questions:
